### PR TITLE
Add :api_keys option for API keys file

### DIFF
--- a/lib/bazil/client.rb
+++ b/lib/bazil/client.rb
@@ -13,7 +13,7 @@ module Bazil
     extend Forwardable
 
     class Options
-      attr_reader :host, :port, :scheme, :ca_file, :ssl_version, :verify_mode
+      attr_reader :host, :port, :scheme, :ca_file, :ssl_version, :verify_mode, :api_key, :secret_key
 
       def initialize(options)
         if options.kind_of? String
@@ -21,29 +21,58 @@ module Bazil
         end
         options = symbolize_keys(options)
 
+        load_url_option(options)
+        load_ca_file_option(options)
+        load_ssl_version_option(options)
+        load_verify_option(options)
+        load_api_keys_option(options)
+      end
+
+      private
+
+      def load_url_option(options)
         url = URI::parse(options[URL_KEY] || DEFAULT_URL)
         @host = url.host or raise "Failed to obtain host name from given url: url = #{url.to_s}"
         @port = url.port or raise "Failed to obtain port number from given url: url = #{url.to_s}"
         @scheme = url.scheme or raise "Failed to obtain scheme from given url: url = #{url.to_s}"
         raise "Unsupported scheme '#{@scheme}'" unless AVAILABLE_SCHEMA.include? @scheme
+      end
 
+      def load_ca_file_option(options)
         @ca_file = options[CA_FILE_KEY] || DEFAULT_CA_FILE
         if @ca_file
           raise "ca_file option must be string value" unless @ca_file.is_a? String
           raise "ca_file option must be absolute path" unless @ca_file[0] == '/'
           raise "ca_file '#{@ca_file}' doesn't exist" unless File::exists? @ca_file
         end
+      end
 
+      def load_ssl_version_option(options)
         ssl_version = options[SSL_VERSION_KEY] || DEFAULT_SSL_VERSION
         raise "Unsupported SSL version '#{ssl_version}'" unless AVAILABLE_SSL_VERSIONS.has_key? ssl_version
         @ssl_version = AVAILABLE_SSL_VERSIONS[ssl_version]
+      end
 
+      def load_verify_option(options)
         skip_verify = options[SKIP_VERIFY_KEY] || DEFAULT_SKIP_VERIFY
         raise "skip_verify option must be boolean value" unless skip_verify.is_a?(TrueClass) || skip_verify.is_a?(FalseClass)
         @verify_mode = skip_verify ?  OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
       end
 
-      private
+      def load_api_keys_option(options)
+        api_keys_file = options[API_KEYS_FILE_KEY] || DEFAULT_API_KEYS_FILES.find{|file|
+          File::readable?(file) && File::file?(file)
+        }
+        raise "API keys file is not found" if api_keys_file.nil?
+
+        api_keys = symbolize_keys(JSON::parse(File::read(api_keys_file)))
+        @api_key = api_keys[API_KEYS_API_KEY_KEY]
+        @secret_key = api_keys[API_KEYS_SECRET_KEY_KEY]
+      rescue SystemCallError, RuntimeError => e
+        STDERR.puts ""
+        STDERR.puts "WARNING: Failed to read api_keys file. Check your api_keys file, or set api_keys manually by set_api_keys(API_KEY, SECRET_KEY): ERROR = #{e.to_s}"
+        STDERR.puts ""
+      end
 
       def symbolize_keys(hash)
         {}.tap{|new_hash|
@@ -66,6 +95,16 @@ module Bazil
 
       SKIP_VERIFY_KEY = :skip_verify
       DEFAULT_SKIP_VERIFY = false
+
+      BAZIL_CONFIG_DIRS = [
+        File::join(ENV['PWD'], '.bazil'),
+        File::join(ENV['HOME'], '.bazil')
+      ]
+
+      API_KEYS_FILE_KEY = :api_keys
+      DEFAULT_API_KEYS_FILES = BAZIL_CONFIG_DIRS.map{|dir| File::join(dir, 'api_keys') }
+      API_KEYS_API_KEY_KEY = :api_key
+      API_KEYS_SECRET_KEY_KEY = :secret_key
     end
 
     def set_ssl_options(http, options)
@@ -79,7 +118,9 @@ module Bazil
       opt = Options.new(options)
       http = Net::HTTP.new(opt.host, opt.port)
       set_ssl_options(http,opt)
+
       @http_cli = REST.new(http)
+      set_api_keys(opt.api_key, opt.secret_key)
     end
 
     def_delegators :@http_cli, :read_timeout, :read_timeout=, :set_api_keys


### PR DESCRIPTION
Add :api_keys option and default api_keys file for Bazil::Client
and small refactoring

See "2. クライアントの作成" in https://github.com/pfi/bazil_ruby_client/wiki/How-to-use
