### PR TITLE
Changed reference URL of source in Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 


### PR DESCRIPTION
irbにて実行すると以下の通知がなされたので変更。sourceはURLを指定しなくてはならなくなったようです。

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
