### PR TITLE
Fix Bazil official domain name

### DIFF
--- a/bazil_client.gemspec
+++ b/bazil_client.gemspec
@@ -4,7 +4,7 @@ $:.push File.expand_path('../lib', __FILE__)
 Gem::Specification.new do |gem|
   gem.name        = "bazil_client"
   gem.description = "Ruby client of Bazil"
-  gem.homepage    = "https://asp-bazil.preferred.jp/"
+  gem.homepage    = "https://bazil.preferred.jp/"
   gem.summary     = gem.description
   gem.version     = File.read("VERSION").strip
   gem.authors     = ["Nobuyuki Kubota"]

--- a/lib/bazil/client.rb
+++ b/lib/bazil/client.rb
@@ -83,7 +83,7 @@ module Bazil
       end
 
       URL_KEY = :url
-      DEFAULT_URL = 'https://asp-bazil.preferred.jp/'
+      DEFAULT_URL = 'https://bazil.preferred.jp/'
       AVAILABLE_SCHEMA = ['http', 'https']
 
       CA_FILE_KEY = :ca_file

--- a/spec/bazil/client_spec.rb
+++ b/spec/bazil/client_spec.rb
@@ -5,7 +5,7 @@ describe Bazil::Client do
     let(:option) { Bazil::Client::Options.new({}) }
 
     it "host name" do
-      expect(option.host).to eq('asp-bazil.preferred.jp')
+      expect(option.host).to eq('bazil.preferred.jp')
     end
 
     it "port name" do


### PR DESCRIPTION
Since official Bazil WebPage move to https://bazil.preferred.jp/, fix default host name.
